### PR TITLE
Fix mobs not catching on soul fire

### DIFF
--- a/src/main/java/moriyashiine/onsoulfire/mixin/AbstractFireBlockMixin.java
+++ b/src/main/java/moriyashiine/onsoulfire/mixin/AbstractFireBlockMixin.java
@@ -26,6 +26,7 @@ public class AbstractFireBlockMixin {
 		boolean onSoulFire = state.getBlock() instanceof SoulFireBlock;
 		if (onSoulFireComponent.isOnSoulFire() != onSoulFire) {
 			onSoulFireComponent.setOnSoulFire(onSoulFire);
+			onSoulFireComponent.sync();
 		}
 	}
 


### PR DESCRIPTION
When a mob enters soul fire, they do not get the soul fire effect. This fixes that.